### PR TITLE
merge from npm-package-walker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         node-version:
           - 20.12.2
-          - 22.0.0
           - 22.1.0
     steps:
       - uses: actions/checkout@v4.1.4


### PR DESCRIPTION
.github/workflows/ci.yml
---
- chore(deps): remove 22.0.0 (jobs.test-node.strategy.matrix.node-version)

