### PR TITLE
merge from npm-package-walker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.16.0
           - 22.5.1
     steps:
       - uses: actions/checkout@v4.1.7


### PR DESCRIPTION
.github/workflows/ci.yml
---
- chore(deps): remove 20.16.0 (jobs.test-node.strategy.matrix.node-version)

